### PR TITLE
Get rid of postrecoveryboot/usbid_init [2/3]

### DIFF
--- a/kumquat-vendor-blobs.mk
+++ b/kumquat-vendor-blobs.mk
@@ -45,7 +45,6 @@ PRODUCT_COPY_FILES += \
     $(VENDOR_DIR)/bin/taimport:system/bin/taimport \
     $(VENDOR_DIR)/bin/ta_reader:system/bin/ta_reader \
     $(VENDOR_DIR)/bin/updatemiscta:system/bin/updatemiscta \
-    $(VENDOR_DIR)/bin/usbid_init.sh:system/bin/usbid_init.sh \
     $(VENDOR_DIR)/bin/wait4tad:system/bin/wait4tad
 
 

--- a/proprietary/bin/usbid_init.sh
+++ b/proprietary/bin/usbid_init.sh
@@ -1,5 +1,0 @@
-#!/system/bin/sh
-
-#cat /sys/devices/platform/ab8500-i2c.0/ab8500-usb.0/serial_number  > /sys/devices/virtual/android_usb/android0/iSerial
-cat /sys/devices/platform/ab8500-i2c.0/ab8500-usb.0/boot_time_device > /sys/devices/platform/ab8500-i2c.0/ab8500-usb.0/boot_time_device
-


### PR DESCRIPTION
Change-Id: I77f6e0c405be3f30ebe779d1a2706117cb0a0cca
